### PR TITLE
fixes TLT-391 - Canvas admins without sis_user_ids

### DIFF
--- a/canvas_course_site_wizard/controller.py
+++ b/canvas_course_site_wizard/controller.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 def create_canvas_course(sis_course_id):
     """This method creates a canvas course for the  sis_course_id provided."""
 
-    new_course = None
     try:
         #1. fetch the course instance info 
         course_data = get_course_data(sis_course_id)
@@ -35,6 +34,7 @@ def create_canvas_course(sis_course_id):
 
     #2. Create canvas course
     try:
+        new_course = None
         request_parameters = dict(request_ctx=SDK_CONTEXT,
                 account_id = 'sis_account_id:' + course_data.sis_account_id,
                 course_name = course_data.course_name,
@@ -49,16 +49,16 @@ def create_canvas_course(sis_course_id):
 
     # 3. Create course section after course  creation
     try:
-        section = create_course_section(
-                    SDK_CONTEXT,
-                    course_id = new_course['id'],
-                    course_section_name = course_data.primary_section_name(),
-                    course_section_sis_section_id = sis_course_id
-                    )
-        logger.info("created section= %s" %(section.json()))
+        section = None
+        request_parameters = dict(request_ctx=SDK_CONTEXT,
+            course_id=new_course['id'],
+            course_section_name=course_data.primary_section_name(),
+            course_section_sis_section_id=sis_course_id)
+        section = create_course_section(**request_parameters).json()
+        logger.info("created section= %s" % section)
     except Exception as e:
-        logger.error('Error creating default section for Canvas course with new_course.request=%s and response=%s: %s'
-                     % (new_course.request, new_course.json(), e))
+        logger.error('Error creating default section for Canvas course with request=%s and response=%s: %s'
+                     % (request_parameters, section, e))
         raise
 
     return new_course

--- a/canvas_course_site_wizard/mixins.py
+++ b/canvas_course_site_wizard/mixins.py
@@ -52,7 +52,9 @@ class CourseDataPermissionsMixin(CourseDataMixin):
         :return: True or False depending on whether user is in staff list
         :rtype: boolean
         """
+
         if not self.object:  # Make sure we have the course data
+            logger.debug('getting object in is_current_user_member_of_course_staff')
             self.object = self.get_object()
 
         staff_group = 'ScaleCourseStaff:%s' % self.object.pk
@@ -72,6 +74,7 @@ class CourseDataPermissionsMixin(CourseDataMixin):
         :raises: Exception from SDK
         """
         if not self.object:  # Make sure we have the course data
+            logger.debug('getting object in list_current_user_admin_roles_for_course')
             self.object = self.get_object()
 
         # List account admins for school associated with course. TLT-382 specified that only school-level admins
@@ -86,8 +89,11 @@ class CourseDataPermissionsMixin(CourseDataMixin):
         logger.debug("Admin list for in sis_account_id:school:%s is %s"
                      % (self.object.school_code, user_account_admin_list))
 
-        matching_users = [a for a in user_account_admin_list if a['user']['sis_user_id'] == self.request.user.username]
-        logger.debug("Matches found for user=%s in admin list: %s" % (self.request.user.username, matching_users))
+        # Chained safe access to dictionary keys, see http://stackoverflow.com/a/14484580/3526824
+        matching_users = [a for a in user_account_admin_list
+                          if a.get('user', {}).get('sis_user_id', {}) == self.request.user.username]
+        logger.debug("Matches found for user=%s in admin list (matching against sis_user_id's in list): %s"
+                     % (self.request.user.username, matching_users))
 
         return matching_users
 

--- a/canvas_course_site_wizard/tests/test_course_data_permissions_mixin.py
+++ b/canvas_course_site_wizard/tests/test_course_data_permissions_mixin.py
@@ -137,3 +137,34 @@ class CourseDataPermissionsMixinTest(TestCase):
         sdk_admins_mock.list_account_admins.return_value.json.return_value = mock_user_list
         return_value = self.mixin.list_current_user_admin_roles_for_course()
         self.assertEqual(return_value, [])
+
+    @patch("canvas_course_site_wizard.mixins.admins")
+    def test_list_current_user_admin_roles_for_course_safely_handle_blank_sis_user_id_no_match(self, sdk_admins_mock):
+        """
+        If the admin list contains users without sis_user_ids (blank or missing), the method should safely handle those.
+        list_account_admins looks for users matching the username in the request by sis_user_id, so it should not make
+        a match when there are blanks for a user in the mock_user_list.
+        """
+        mock_user = {"user": {"id": 1, "sis_user_id": ""}}
+        mock_other_user = {"user": {"id": 2, "sis_user_id": "67890"}}
+        mock_third_user = {"user": {"id": 3}}
+        mock_user_list = [mock_user, mock_other_user, mock_third_user]
+        sdk_admins_mock.list_account_admins.return_value.json.return_value = mock_user_list
+        return_value = self.mixin.list_current_user_admin_roles_for_course()
+        self.assertEqual(return_value, [])
+
+    @patch("canvas_course_site_wizard.mixins.admins")
+    def test_list_current_user_admin_roles_for_course_safely_handle_blank_sis_user_id_match_found(self, sdk_admins_mock):
+        """
+        If the admin list contains users without sis_user_ids (blank or missing), the method should safely handle those.
+        list_account_admins looks for users matching the username in the request by sis_user_id, so it should not make
+        a match when there are blanks for a user in the mock_user_list, but it should continue to look for matches.
+        """
+        mock_user = {"user": {"id": 1}}
+        mock_other_user = {"user": {"id": 2, "sis_user_id": "67890"}}
+        mock_third_user = {"user": {"id": 3, "sis_user_id": self.mixin.request.user.username}}
+        mock_user_list = [mock_user, mock_other_user, mock_third_user]
+        sdk_admins_mock.list_account_admins.return_value.json.return_value = mock_user_list
+        return_value = self.mixin.list_current_user_admin_roles_for_course()
+        self.assertEqual(return_value[0], mock_third_user)
+        self.assertEqual(len(return_value), 1)


### PR DESCRIPTION
Canvas admins without sis_user_ids no longer cause admin lookup to fail
