### PR TITLE
Task/sapnamysore/tlt 1366 modify methods for bulk

### DIFF
--- a/canvas_course_site_wizard/controller.py
+++ b/canvas_course_site_wizard/controller.py
@@ -24,18 +24,14 @@ logger = logging.getLogger(__name__)
 
 
 def create_canvas_course(sis_course_id, sis_user_id, bulk_job_id=None):
-    """This method creates a canvas course for the sis_course_id provided, initiated by the sis_user_id. The bulk_job_id
-        would be passed in if it's invoked from a bulk feed process.
+    """
+    This method creates a canvas course for the sis_course_id provided, initiated by the sis_user_id. The bulk_job_id
+    would be passed in if it's invoked from a bulk feed process.
     """
 
     # instantiate any variables required for method return or logger calls
     new_course = None
     section = None
-    bulk_job_flag = False
-
-    # if the bulk_job_id is not None, set the bulk_job_flag
-    if bulk_job_id is not None:
-        bulk_job_flag = True
 
     try:
         # 1. fetch the course instance info
@@ -48,10 +44,10 @@ def create_canvas_course(sis_course_id, sis_user_id, bulk_job_id=None):
                      'with sis_course_id=%s: exception=%s' % (sis_course_id, e))
 
         ex = SISCourseDoesNotExistError(sis_course_id)
-        #If the course is part of bulk job, do not send individual email. .
-        if not bulk_job_flag:
+        # If the course is part of bulk job, do not send individual email. .
+        if not bulk_job_id:
             msg = ex.display_text
-            #TLT-393: send an email to support group, in addition to showing error page to user
+            # TLT-393: send an email to support group, in addition to showing error page to user
             send_failure_msg_to_support(sis_course_id, sis_user_id, msg)
         raise ex
 
@@ -75,7 +71,7 @@ def create_canvas_course(sis_course_id, sis_user_id, bulk_job_id=None):
             raise CanvasCourseAlreadyExistsError(msg_details=sis_course_id)
 
         ex = CanvasCourseCreateError(msg_details=sis_course_id)
-        if not bulk_job_flag:
+        if not bulk_job_id:
             send_failure_msg_to_support(sis_course_id, sis_user_id, ex.display_text)
         raise ex
 
@@ -93,9 +89,9 @@ def create_canvas_course(sis_course_id, sis_user_id, bulk_job_id=None):
         logger.exception('Error building request_parameters or executing create_course_section() SDK call '
                          'for new Canvas course id=%s with request=%s'
                          % (new_course.get('id', '<no ID>'), request_parameters))
-        #send email in addition to showing error page to user
+        # send email in addition to showing error page to user
         ex = CanvasSectionCreateError(msg_details=sis_course_id)
-        if not bulk_job_flag:
+        if not bulk_job_id:
             send_failure_msg_to_support(sis_course_id, sis_user_id, ex.display_text)
         raise ex
 
@@ -114,11 +110,6 @@ def start_course_template_copy(sis_course, canvas_course_id, user_id, bulk_job_i
     """
 
     school_code = sis_course.school_code
-
-    # if the bulk_job_id is not None, set the bulk flag
-    if bulk_job_id:
-        bulk_job_flag = True
-
 
     try:
         logger.debug('Fetching template for school_code=%s...' % school_code)
@@ -174,14 +165,14 @@ def finalize_new_canvas_course(canvas_course_id, sis_course_id, user_id, bulk_jo
     Enroll instructor/creator if this is a single course creation, but not if it is part of bulk job
     creation.(TLT-1132)
     """
-    if bulk_job_id is None:
+    if not bulk_job_id:
         try:
             enrollment = enroll_creator_in_new_course(sis_course_id, user_id)
-            logger.info('Enrolled user_id=%s in new course with Canvas course id=%s' % (user_id, canvas_course_id))
-            logger.debug("enrollment result: %s" % enrollment)
+            logger.info('Enrolled user_id=%s in new course with Canvas course id=%s', user_id, canvas_course_id)
+            logger.debug("enrollment result: %s", enrollment)
         except Exception as e:
-            logger.exception('Error enrolling course creator with user_id=%s in new course with Canvas course id=%s:'
-                             % (user_id, canvas_course_id))
+            logger.exception('Error enrolling course creator with user_id=%s in new course with Canvas course id=%s:',
+                             user_id, canvas_course_id)
             raise CanvasEnrollmentError(sis_course_id)
 
     # Copy SIS enrollments to new Canvas course
@@ -305,6 +296,7 @@ def send_failure_email(initiator_email, sis_course_id):
                  % (to_address, settings.CANVAS_EMAIL_NOTIFICATION['course_migration_failure_body']))
     send_email_helper(settings.CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'], complete_msg, to_address)
 
+
 def send_failure_msg_to_support(sis_course_id, sis_user_id, error_detail):
     """
     This is a utility to send an email to the support group when there is a  failure in course creation . 
@@ -318,9 +310,12 @@ def send_failure_msg_to_support(sis_course_id, sis_user_id, error_detail):
     # send message to the support group
     to_address.append(settings.CANVAS_EMAIL_NOTIFICATION['support_email_address'])
     msg = settings.CANVAS_EMAIL_NOTIFICATION['support_email_body_on_failure']
-    complete_msg = msg.format(sis_course_id, sis_user_id, error_detail,settings.CANVAS_EMAIL_NOTIFICATION['environment'] )
-    logger.debug(" send_failure_msg_to_support: sis_course_id=%s, user=%s, complete_msg=%s" % (sis_course_id, sis_user_id, complete_msg))
+    complete_msg = msg.format(sis_course_id, sis_user_id, error_detail,
+                              settings.CANVAS_EMAIL_NOTIFICATION['environment'])
+    logger.debug(" send_failure_msg_to_support: sis_course_id=%s, user=%s, complete_msg=%s",
+                 sis_course_id, sis_user_id, complete_msg)
     send_email_helper(settings.CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'], complete_msg, to_address)
+
 
 def get_canvas_course_url(canvas_course_id=None, sis_course_id=None, override_base_url=None):
     """
@@ -355,22 +350,24 @@ def get_canvas_course_url(canvas_course_id=None, sis_course_id=None, override_ba
 
     return course_url
 
+
 def get_term_course_counts(term_id):
     """
     return a dict that contains the following:
         {
             'total_courses' : integer,  Total number of courses in the term
-            'canvas_courses' : integer, Total numner of courses that already have Canvas sites
-            'not_in_canvas' : integer,  Total numner of courses that do not have Canvas sites (this is just total_courses - canvas_courses)
+            'canvas_courses' : integer, Total number of courses that already have Canvas sites
+            'not_in_canvas' : integer,  Total number of courses that do not have Canvas sites (this is just
+                                        total_courses - canvas_courses)
         }
     :param term_id: the term_id of the term from the course manager database
     :return: Method returns dict
     """
     data = {
-        'total_courses' : get_courses_for_term(term_id), # will be 0 if no courses returned
-        'canvas_courses' : get_courses_for_term(term_id, is_in_canvas=True), # will be 0 if no courses returned
+        'total_courses': get_courses_for_term(term_id),  # will be 0 if no courses returned
+        'canvas_courses': get_courses_for_term(term_id, is_in_canvas=True),  # will be 0 if no courses returned
     }
-    data['not_in_canvas'] = data['total_courses'] - data['canvas_courses'] # will be 0 if no courses returned above
+    data['not_in_canvas'] = data['total_courses'] - data['canvas_courses']  # will be 0 if no courses returned above
 
     return data
 
@@ -382,6 +379,7 @@ def is_bulk_job_in_progress(term_id):
     :return:
     """
     return get_bulk_job_records_for_term(term_id, in_progress=True).count() > 0
+
 
 def get_bulk_jobs_for_term(term_id):
     """

--- a/canvas_course_site_wizard/models.py
+++ b/canvas_course_site_wizard/models.py
@@ -152,14 +152,14 @@ class CanvasContentMigrationJob(models.Model):
     STATUS_FINALIZE_FAILED = 'finalize_failed'
     # Workflow status choices
     WORKFLOW_STATUS_CHOICES = (
+        (STATUS_SETUP, STATUS_SETUP),
+        (STATUS_SETUP_FAILED, STATUS_SETUP_FAILED),
         (STATUS_QUEUED, STATUS_QUEUED),
         (STATUS_RUNNING, STATUS_RUNNING),
         (STATUS_COMPLETED, STATUS_COMPLETED),
         (STATUS_FAILED, STATUS_FAILED),
         (STATUS_FINALIZED, STATUS_FINALIZED),
-        (STATUS_FINALIZED, STATUS_FINALIZED),
-        (STATUS_SETUP,STATUS_SETUP),
-        (STATUS_SETUP_FAILED,STATUS_SETUP_FAILED),
+        (STATUS_FINALIZE_FAILED, STATUS_FINALIZE_FAILED),
     )
     canvas_course_id = models.IntegerField(max_length=10, db_index=True)
     sis_course_id = models.CharField(max_length=20, db_index=True)
@@ -171,7 +171,6 @@ class CanvasContentMigrationJob(models.Model):
     created_by_user_id = models.CharField(max_length=20)
     bulk_job_id = models.IntegerField(max_length=11, null=True, blank=True)
 
-    
     class Meta:
         db_table = u'canvas_content_migration_job'
 

--- a/canvas_course_site_wizard/tests/test_async_command.py
+++ b/canvas_course_site_wizard/tests/test_async_command.py
@@ -50,7 +50,6 @@ class CommandsTestCase(TestCase):
         self.status_check = {
             'workflow_state': 'completed',
         }
-        self.bulk_job_id = None,
         self.migration = self.create_migration_job_from_setup()
 
     def create_migration_job_from_setup(self):
@@ -68,7 +67,7 @@ class CommandsTestCase(TestCase):
         spec=CanvasContentMigrationJob,
         id=2,
         bulk_job_id=2,
-        canvas_course_id = 12345,
+        canvas_course_id=12345,
         sis_course_id=6789,
         status_url='http://example.com/1234',
         created_by_user_id='123'
@@ -109,28 +108,13 @@ class CommandsTestCase(TestCase):
         send_email_helper.assert_called_once_with(ANY, ANY, ANY)
 
     @patch('canvas_course_site_wizard.management.commands.process_async_jobs.CanvasContentMigrationJob.objects.filter')
-    def test_process_async_jobs_doesnt_send_email_for_bulk_created_course_on_completed_status(self, filter_mock, client,
-                                                                                              send_email_helper, tech_logger, **kwargs):
-        """
-        test that the send_email_helper is not called for a bulk created course,
-        when the workflow_state of the job changes to 'completed'
-        """
-        mock_client_json(client, 'completed')
-        iterable_ccmjob_mock = MagicMock()
-        filter_mock.return_value = iterable_ccmjob_mock
-        iterable_ccmjob_mock.__iter__ = Mock(return_value=iter([self.m_canvas_content_migration_job_with_bulk_id]))
-
-        start_job_with_noargs()
-        self.assertFalse(send_email_helper.called)
-
-    @patch('canvas_course_site_wizard.management.commands.process_async_jobs.CanvasContentMigrationJob.objects.filter')
-    def test_process_async_jobs_doesnt_send_email_for_bulk_created_course_on_any_status(self, filter_mock, client,
-                                                                                           send_email_helper, **kwargs):
+    def test_process_async_jobs_doesnt_send_email_for_bulk_created_course(self, filter_mock, client,
+                                                                          send_email_helper, **kwargs):
         """
         test that the send_email_helper is not called for a bulk created course,
         irrespective of the workflow_state
         """
-        mock_client_json(client, ANY)
+        mock_client_json(client, 'this can be anything')
         iterable_ccmjob_mock = MagicMock()
         filter_mock.return_value = iterable_ccmjob_mock
         iterable_ccmjob_mock.__iter__ = Mock(return_value=iter([self.m_canvas_content_migration_job_with_bulk_id]))

--- a/canvas_course_site_wizard/tests/test_controller_create_canvas_course.py
+++ b/canvas_course_site_wizard/tests/test_controller_create_canvas_course.py
@@ -15,8 +15,8 @@ class CreateCanvasCourseTest(TestCase):
 
     def setUp(self):
         self.sis_course_id = "305841"
-        self.sis_user_id="123456"
-        self.bulk_job_id="10"
+        self.sis_user_id = "123456"
+        self.bulk_job_id = 10
 
     def get_mock_of_get_course_data(self):
         # mock the properties
@@ -180,7 +180,8 @@ class CreateCanvasCourseTest(TestCase):
 
         with self.assertRaises(SISCourseDoesNotExistError):
             controller.create_canvas_course(self.sis_course_id, self.sis_user_id, self.bulk_job_id)
-            self.assertFalse(send_failure_msg_to_support.called)
+
+        self.assertFalse(send_failure_msg_to_support.called)
 
     @patch('canvas_course_site_wizard.controller.send_failure_msg_to_support')
     def test_canvas_course_create_error_sends_support_email(self, send_failure_msg_to_support, get_course_data,
@@ -236,7 +237,6 @@ class CreateCanvasCourseTest(TestCase):
         """
         create_course_section.side_effect = CanvasAPIError(status_code=400)
 
-        exception_data = CanvasSectionCreateError(self.sis_course_id)
         with self.assertRaises(CanvasSectionCreateError):
             controller.create_canvas_course(self.sis_course_id, self.sis_user_id, self.bulk_job_id)
 
@@ -251,7 +251,6 @@ class CreateCanvasCourseTest(TestCase):
         
         """
         create_new_course.side_effect = CanvasAPIError(status_code=400)
-        exception_data = CanvasCourseAlreadyExistsError(self.sis_course_id)
         with self.assertRaises(CanvasCourseAlreadyExistsError):
             controller.create_canvas_course(self.sis_course_id, self.sis_user_id)
         
@@ -269,7 +268,7 @@ class CreateCanvasCourseTest(TestCase):
         with self.assertRaises(CanvasSectionCreateError):
             controller.create_canvas_course(self.sis_course_id, self.sis_user_id)
 
-        self.assertTrue(True, exception_data.support_notified)
+        self.assertTrue(exception_data.support_notified)
 
     @patch('canvas_course_site_wizard.controller.send_failure_msg_to_support')
     def test_canvas_course_create_error_sets_support_notified(self, send_failure_msg_to_support, get_course_data,
@@ -282,7 +281,7 @@ class CreateCanvasCourseTest(TestCase):
         with self.assertRaises(CanvasCourseCreateError):
             controller.create_canvas_course(self.sis_course_id, self.sis_user_id)
 
-        self.assertEqual(True,exception_data.support_notified)
+        self.assertTrue(exception_data.support_notified)
 
     @patch('canvas_course_site_wizard.controller.send_failure_msg_to_support')
     def test_canvas_course_already_exists_error_doesnt_set_support_notified(self, send_failure_msg_to_support, get_course_data,

--- a/canvas_course_site_wizard/tests/test_controller_finalize_new_canvas_course.py
+++ b/canvas_course_site_wizard/tests/test_controller_finalize_new_canvas_course.py
@@ -14,7 +14,7 @@ class FinalizeNewCanvasCourseTest(TestCase):
         self.sis_course_id = '123456'
         self.user_id = 999
         self.test_return_value = None
-        self.bulk_job_id =10
+        self.bulk_job_id = 10
 
     def test_finalization_success(self, enroll_creator_in_new_course, logger, get_course_data, get_canvas_course_url):
         """

--- a/canvas_course_site_wizard/views.py
+++ b/canvas_course_site_wizard/views.py
@@ -31,7 +31,7 @@ class CanvasCourseSiteCreateView(LoginRequiredMixin, CourseSiteCreationAllowedMi
         sis_user_id = 'sis_user_id:%s' % request.user.username
         course = create_canvas_course(sis_course_id, request.user.username)
         try:
-            migration_job = start_course_template_copy(self.object, course['id'], request.user.username, None)
+            migration_job = start_course_template_copy(self.object, course['id'], request.user.username)
             return redirect('ccsw-status', migration_job.pk)
         except NoTemplateExistsForSchool:
             # If there is no template to copy, immediately finalize the new course


### PR DESCRIPTION
This PR contains changes for TLT-1366 and TLT-1361
-Modify existing methods to in controller and async_job to add bulk_job_id param and logic to process the bulk_job_id accordingly 
-change to not  enroll the creator in the course,  if it's a bulk job
- some new workflow states in the model to accommodate the bulk job to handle pre-migration statuses
  -update existing cron job to send email only if there is no bulk_id for the job
- Fixed broken unit tests and added some new ones
