### PR TITLE
Sprint 23 Bugfix: tag SISCourseData as an icommons-common model

### DIFF
--- a/canvas_course_site_wizard/models.py
+++ b/canvas_course_site_wizard/models.py
@@ -144,6 +144,7 @@ class SISCourseData(CourseInstance, SISCourseDataMixin):
     Database-backed SIS course information that implements mixin.
     """
     class Meta:
+        app_label = 'icommons_common'
         proxy = True
 
 


### PR DESCRIPTION
SISCourseData proxies to icommons_common.models.CourseInstance, which (in development and the dev/qa/stage environments) is stored in a different database than the other models in that app.  In order to get queries on it to work correctly in those environments, we need to explicitly tag it with the icommons_common app label.
