### PR TITLE
course wizard: status page now shows correct status

### DIFF
--- a/canvas_course_site_wizard/templates/canvas_course_site_wizard/status.html
+++ b/canvas_course_site_wizard/templates/canvas_course_site_wizard/status.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-    {% if content_migration_job.workflow_state == 'completed' %}
+    {% if job_succeeded %}
         <h1>Success!</h1>
         <p>Your new Canvas course site has been created and is ready for you at:
             <br />
@@ -14,7 +14,7 @@
             Resources for getting started with your site:
             <a href="http://tlt.harvard.edu/getting-started">http://tlt.harvard.edu/getting-started</a>
         </p>
-    {% elif content_migration_job.workflow_state == 'failed' %}
+    {% elif job_failed %}
         <h1>Oops!</h1>
         <p>Sadly, there was a problem. Please notify your local academic support staff:</p>
         <ul>

--- a/canvas_course_site_wizard/views.py
+++ b/canvas_course_site_wizard/views.py
@@ -47,20 +47,26 @@ class CanvasCourseSiteCreateView(LoginRequiredMixin, CourseSiteCreationAllowedMi
 
 
 class CanvasCourseSiteStatusView(LoginRequiredMixin, DetailView):
-    """ Displays status of async job for template copy """
+    """ Displays status of course creation job, including progress and result of template copy and finalization """
     template_name = "canvas_course_site_wizard/status.html"
     model = CanvasCourseGenerationJob
     context_object_name = 'content_migration_job'
 
     def get_context_data(self, **kwargs):
         """
-        get_context_data allows us to pass additional values to the view.
-        In this case I am passing in the canvas course url created by the calling
-        get_canvas_course_url.
+        get_context_data allows us to pass additional values to the view. In this case we are passing in:
+        - the canvas course url for a successfully completed job (or None if it hasn't successfully completed)
+        - simplified job progress status indicators for the template to display success/failure messages
         """
         context = super(CanvasCourseSiteStatusView, self).get_context_data(**kwargs)
         logger.debug('Rendering status page for course generation job %s' % self.object)
         context['canvas_course_url'] = get_canvas_course_url(canvas_course_id=self.object.canvas_course_id)
+        context['job_failed'] = self.object.workflow_state in [
+            CanvasCourseGenerationJob.STATUS_FAILED,
+            CanvasCourseGenerationJob.STATUS_SETUP_FAILED,
+            CanvasCourseGenerationJob.STATUS_FINALIZE_FAILED
+        ]
+        context['job_succeeded'] = self.object.workflow_state in [CanvasCourseGenerationJob.STATUS_FINALIZED]
         return context
 
 


### PR DESCRIPTION
Changes to job workflow states introduced by the bulk job create process code meant that the status page was no longer showing the expected statuses for new jobs. Note that _old_ jobs, for which `workflow_state == STATUS_COMPLETED and status_url is not None`, will _not_ show up on the status page as successful with this fix. This will only work for new jobs. If we want to fix this for old (pre-bulk) jobs we'd have to consider whether new jobs would ever get into the state mentioned above (which would probably be an intermediate state for new jobs, not a terminal state as it was for old jobs).
