### PR TITLE
Sprint 23 Throw an exception if get_course_generation_data_for_sis_course_id has multiple matches

### DIFF
--- a/canvas_course_site_wizard/models_api.py
+++ b/canvas_course_site_wizard/models_api.py
@@ -53,7 +53,7 @@ def get_course_generation_data_for_sis_course_id(sis_course_id,
             kwargs['bulk_job_id__isnull'] = True
 
     try:
-        return CanvasCourseGenerationJob.objects.filter(**kwargs).get()
+        return CanvasCourseGenerationJob.objects.get(**kwargs)
     except (CanvasCourseGenerationJob.DoesNotExist,
             CanvasCourseGenerationJob.MultipleObjectsReturned) as e:
         logger.exception(

--- a/canvas_course_site_wizard/tests/test_models_api.py
+++ b/canvas_course_site_wizard/tests/test_models_api.py
@@ -67,7 +67,7 @@ class ModelsApiTest(TestCase):
         mock_ci.assert_called_once_with(term__term_id=self.term_id, sync_to_canvas=True)
 
     def test_get_bulk_job_records_for_term(self):
-        """ test that the call to the bulk_job model reutrns the correct results when only the term_id is provided """
+        """ test that the call to the bulk_job model returns the correct results when only the term_id is provided """
         test_data_set = [
             '<BulkCanvasCourseCreationJob: (BulkJob ID=2: sis_term_id=4545)>',
             '<BulkCanvasCourseCreationJob: (BulkJob ID=5: sis_term_id=4545)>',
@@ -108,7 +108,7 @@ class ModelsApiTest(TestCase):
 
         mock_ci.assert_has_calls(calls, any_order=True)
 
-    @patch('canvas_course_site_wizard.models_api.CanvasCourseGenerationJob.objects.filter')
+    @patch('canvas_course_site_wizard.models_api.CanvasCourseGenerationJob.objects.get')
     def test_get_course_generation_data_for_sis_course_id_without_bulk_job_id(self, mock_ci):
         """
         Test that get_course_generation_data_for_sis_course_id has the proper query when no
@@ -119,7 +119,7 @@ class ModelsApiTest(TestCase):
         get_course_generation_data_for_sis_course_id(self.sis_course_id)
         mock_ci.assert_called_once_with(sis_course_id=self.sis_course_id, bulk_job_id__isnull=True)
 
-    @patch('canvas_course_site_wizard.models_api.CanvasCourseGenerationJob.objects.filter')
+    @patch('canvas_course_site_wizard.models_api.CanvasCourseGenerationJob.objects.get')
     def test_get_course_generation_data_for_sis_course_id(self, mock_ci):
         """
         Test that get_course_generation_data_for_sis_course_id has the proper query when the

--- a/canvas_course_site_wizard/tests/test_models_api_job_migration.py
+++ b/canvas_course_site_wizard/tests/test_models_api_job_migration.py
@@ -66,13 +66,37 @@ class ModelsApiTestJobMigration(TestCase):
         self.assertEqual(ret, None)
 
     def test_multiple_migration_jobs__for_sis_course_id(self):
-        """ Test that the method will  return first matching record if there are multiple records """
+        """ Test that the method will raise a MultipleObjectsReturned exception if multiple course jobs are returned """
         CanvasCourseGenerationJob.objects.create(canvas_course_id=self.canvas_course_id,
-             sis_course_id=self.sis_course_id, content_migration_id = self.content_migration_id, 
-             status_url=self.status_url, created_by_user_id="user1")        
+                                                 sis_course_id=self.sis_course_id,
+                                                 content_migration_id = self.content_migration_id,
+                                                 status_url=self.status_url,
+                                                 created_by_user_id="user1")
+
         CanvasCourseGenerationJob.objects.create(canvas_course_id=self.canvas_course_id,
-             sis_course_id=self.sis_course_id, content_migration_id = self.content_migration_id, 
-             status_url=self.status_url, created_by_user_id="user2")
-        ret = get_course_generation_data_for_sis_course_id(self.sis_course_id)
-        self.assertEqual(ret.created_by_user_id,"user1")
+                                                 sis_course_id=self.sis_course_id,
+                                                 content_migration_id = self.content_migration_id,
+                                                 status_url=self.status_url,
+                                                 created_by_user_id="user2")
+
+
+        self.assertRaises(CanvasCourseGenerationJob.MultipleObjectsReturned,
+                          get_course_generation_data_for_sis_course_id(self.sis_course_id))
+
+    def test_multiple_migration_jobs__for_sis_course_id_with_one_value(self):
+        """ Test that the method will return the correct course if there exists only one matching course """
+        CanvasCourseGenerationJob.objects.create(canvas_course_id=self.canvas_course_id,
+                                                 sis_course_id=self.sis_course_id,
+                                                 content_migration_id = self.content_migration_id,
+                                                 status_url=self.status_url,
+                                                 created_by_user_id="user1")
+
+        CanvasCourseGenerationJob.objects.create(canvas_course_id=self.canvas_course_id,
+                                                 sis_course_id=123456,
+                                                 content_migration_id = self.content_migration_id,
+                                                 status_url=self.status_url,
+                                                 created_by_user_id="user2")
+
+        ret = get_course_generation_data_for_sis_course_id(123456)
+        self.assertEqual(ret.created_by_user_id, "user2")
 


### PR DESCRIPTION
Let's be super paranoid about lookup of course jobs, and throw an exception if there is anything but one and only one match.

Thanks to @eparker71 for this.
