### PR TITLE
Sprint 26 TLT-1759 Bulk Job creation with no template

### DIFF
--- a/canvas_course_site_wizard/management/commands/finalize_bulk_create_jobs.py
+++ b/canvas_course_site_wizard/management/commands/finalize_bulk_create_jobs.py
@@ -146,8 +146,7 @@ def _init_courses_with_status_setup():
             course = create_canvas_course(
                 sis_course_id,
                 sis_user_id,
-                bulk_job_id=bulk_job_id,
-                template_id=bulk_job.template_canvas_course_id
+                bulk_job=bulk_job,
             )
         except (CanvasCourseAlreadyExistsError, CourseGenerationJobCreationError, CanvasCourseCreateError,
                 CanvasSectionCreateError):

--- a/canvas_course_site_wizard/tests/test_command_finalize_init_courses_with_status_setup.py
+++ b/canvas_course_site_wizard/tests/test_command_finalize_init_courses_with_status_setup.py
@@ -67,7 +67,7 @@ class FinalizeInitCoursesWithStatusSetupCommandTests(TestCase):
         template_copy_calls = []
         for index, course in enumerate(self.courses):
             create_course_calls.append(
-                call(course, self.user_id, bulk_job_id=self.bulk_job_id, template_id=self.template_id)
+                call(course, self.user_id, bulk_job=BulkCanvasCourseCreationJob(id=self.bulk_job_id))
             )
             create_course_calls.append(ANY)
             template_copy_calls.append(


### PR DESCRIPTION
If "No template" was selected when creating a bulk job, make sure that we do not copy over any visibility settings from a potential default template when creating the new courses.
