### PR TITLE
Remove dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "Django>=3.0,<4.0",
         "django-braces",
         "canvas-python-sdk>=1.0",
-        "django-icommons-common[async_operations]>=2.0",
     ],
     tests_require=[
         'mock',


### PR DESCRIPTION
async_operations has been moved to CAAT and is no longer required here, see [PR here ](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/pull/355) for the change in CAAT.